### PR TITLE
always use vertical split for portrait monitors

### DIFF
--- a/i3altlayout/i3altlayout.py
+++ b/i3altlayout/i3altlayout.py
@@ -56,10 +56,18 @@ def on_window_focus(i3, event):
     width = window.rect.width
     log('height: {}, width: {}'.format(height, width))
 
-    if height > width:
+    """aspect ratio rule BUT always split vertical if the screen is portrait.
+       Rationale: it's uncommon to have applications that work well on very tiny width"""
+    workspace_height = window.workspace().rect.height
+    workspace_width = window.workspace().rect.width
+    if workspace_height > workspace_width:
         layout = 'vertical'
     else:
-        layout = 'horizontal'
+        if height > width:
+            layout = 'vertical'
+        else:
+            layout = 'horizontal'
+
     cmd = 'split {}'.format(layout)
     log('running command: {}'.format(cmd))
     i3.command(cmd)


### PR DESCRIPTION
Hi! 
Thanks for this script.
I'm using an i3 setup with an horizontal plus a vertical screen and I found quite inconvinient to use the default split rule on the latter, the reason being it's quite uncommon to find applications that work well on 1080/2 = 540 pixels width (or less).
So I made the default split rule to be vertical for portrait screens. I hope this contribution makes sense for you, please let me know any comments