### PR TITLE
Fix setuptools warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
-description-file = README.md
-license_file = LICENSE
+description_file = README.md
+license_files = LICENSE
 
 [bdist_wheel]
 python-tag = py3


### PR DESCRIPTION
- The license_file parameter is deprecated, use license_files instead
- Usage of dash-separated 'description-file' will not be supported in
  future versions. Please use the underscore name 'description_file'
  instead